### PR TITLE
Install fixed vector.dev version

### DIFF
--- a/.github/workflows/datadog.yml
+++ b/.github/workflows/datadog.yml
@@ -13,11 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: sudo apt-get install --yes curl bc
-    - run:  curl --proto '=https' --tlsv1.2 -sSf https://sh.vector.dev | bash -s -- -y
-    - run: ~/.vector/bin/vector --version
+    - run: curl -L https://packages.timber.io/vector/0.22.2/vector-x86_64-unknown-linux-gnu.tar.gz -o vector.tar.gz
+    - run: tar -xzvf vector.tar.gz
+    - run: sudo mv vector-x86_64-unknown-linux-gnu/bin/vector /usr/local/bin/vector
+    - run: vector --version
     - name: pipes_stats_to_datadog
       run: |
-        curl "https://${TB_HOST}.tinybird.co/v0/pipes/ep_datadog_pipes_stats.ndjson?token=${TB_TOKEN}" | ~/.vector/bin/vector --config ./vector-pipes-stats.toml
+        curl "https://${TB_HOST}.tinybird.co/v0/pipes/ep_datadog_pipes_stats.ndjson?token=${TB_TOKEN}" | vector --config ./vector-pipes-stats.toml
       env:
         TB_TOKEN: ${{ secrets.TB_TOKEN }}
         TB_HOST: ${{ secrets.TB_HOST }}
@@ -25,7 +27,7 @@ jobs:
         DATADOG_REGION: ${{ secrets.DATADOG_REGION }}
     - name: ops_log_to_datadog
       run: |
-        curl "https://${TB_HOST}.tinybird.co/v0/pipes/ep_datadog_ops_log.ndjson?token=${TB_TOKEN}" | ~/.vector/bin/vector --config ./vector-ops-log.toml
+        curl "https://${TB_HOST}.tinybird.co/v0/pipes/ep_datadog_ops_log.ndjson?token=${TB_TOKEN}" | vector --config ./vector-ops-log.toml
       env:
         TB_TOKEN: ${{ secrets.TB_TOKEN }}
         TB_HOST: ${{ secrets.TB_HOST }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This data project demonstrates how users can integrate [Tinybird](https://tinybird.co) with [Datadog](https://datadog.com/) bulding endpoints on top of the [Tinybird Service Data Sources](https://docs.tinybird.co/monitoring/service-datasources.html) and using [vector.dev](https://vector.dev).
 
+> Note: This example uses vector.dev version 0.22.2. We're not actively maintaining this example. If you want to use a newer version, you would have to update the configuration from `vector-ops-log.toml` and `vector-pipes-stats.toml`.
+
 The project is defined by:
 
 - **Data project**: The Tinybird data project


### PR DESCRIPTION
## Description

The current vector installation was failing. We need to use a fixed version to keep the current config compatible, as new versions have incompatible backward changes.